### PR TITLE
arbitrary walkee can see arbitrary walker live walk path on map now

### DIFF
--- a/client/auth-context.js
+++ b/client/auth-context.js
@@ -2,7 +2,13 @@ import React from 'react'
 
 const authContext = React.createContext({
     user_id : 0,
-    login : ()=>{}
+    login : ()=>{},
+
+    current_walk_route_id : 0,
+    current_user_type: null,
+    set_user_type : ()=>{},
+    set_current_walk_route_id : ()=>{},
+    set_current_walk_paired_user_id : () =>{}
 });
 
 

--- a/client/components/app.jsx
+++ b/client/components/app.jsx
@@ -18,12 +18,14 @@ class App extends React.Component {
     this.state = {
       user_id : 1,
       current_walk_route_id : 0,
-      user_type: null
-      
+      current_walk_paired_user_id: 0,
+      user_type: null,
+
     };
     this.login = this.login.bind(this);
     this.set_user_type = this.set_user_type.bind(this);
     this.set_current_walk_route_id = this.set_current_walk_route_id.bind(this);
+    this.set_current_walk_paired_user_id = this.set_current_walk_paired_user_id.bind(this);
 
   }
 
@@ -39,25 +41,48 @@ class App extends React.Component {
     this.setState({current_walk_route_id})
   }
 
-  componentWillUnmount(){
-    this.set_current_walk_route_id = null;
-    this.set_user_type = null;
+  set_current_walk_paired_user_id(current_walk_paired_user_id){
+    this.setState({current_walk_paired_user_id})
   }
 
+  componentDidUpdate(){
+    console.log(this.state)
+  }
+
+  componentWillUnmount(){
+    // this.set_current_walk_route_id = null;
+    // this.set_user_type = null;
+  }
+
+
+
   render() {
+
+    const contextValue = {
+      user_id: this.state.user_id,
+      login: this.login,
+      current_walk_route_id : this.state.current_walk_route_id,
+      current_user_type: this.state.current_user_type,
+      set_user_type : this.set_user_type,
+      set_current_walk_route_id : this.set_current_walk_route_id,
+      set_current_walk_paired_user_id : this.set_current_walk_paired_user_id,
+    }
+
     return (
       <BrowserRouter>
-      <AuthContext.Provider value={{
-          user_id: this.state.user_id,
-          login: this.login
-        }}>
+
+      <AuthContext.Provider value={contextValue}>
         <div className="app">
           ROOT PAGE
 
           <Switch>
             <Route path="/home" component={HomePage}></Route>
-            <Route path="/live-walkee" component={WalkeeMap}></Route> :
-            <Route path="/live-walker" component={()=><WalkerMap route_id={this.state.current_walk_route_id}/>}></Route>
+            <Route path="/live-walkee" component={()=> <WalkeeMap />}></Route> :
+            <Route path="/live-walker" 
+              component={()=><WalkerMap 
+                walkee_id = {this.state.current_walk_paired_user_id}
+                route_id={this.state.current_walk_route_id}/>}>
+            </Route>
 
             <Route path='/user-requests' render={
               (props)=> 

--- a/client/components/home-page.jsx
+++ b/client/components/home-page.jsx
@@ -17,12 +17,21 @@ class HomePage extends React.Component {
                 <button>Back to login</button>
             </NavLink>
 
-            <NavLink to='/live-walking'>
+            <NavLink to='/live-walker'>
                 <div className="button">
                     <button>
                         <i className="fas fas fa-road"></i>
                     </button>
-                    LIVE WALKING
+                    LIVE Walker
+                </div>
+            </NavLink>
+
+            <NavLink to='/live-walkee'>
+                <div className="button">
+                    <button>
+                        <i className="fas fas fa-road"></i>
+                    </button>
+                    LIVE Walkee
                 </div>
             </NavLink>
 

--- a/client/components/user-requests.jsx
+++ b/client/components/user-requests.jsx
@@ -15,6 +15,7 @@ class UserRequests extends React.Component {
       request_type : 'my-walk',
       showModal: false,
       pickedRouteId : null,
+      walkee_id: null,
     };
     this.changeRequestType = this.changeRequestType.bind(this)
     this.chooseAWalkPlan = this.chooseAWalkPlan.bind(this);
@@ -29,10 +30,11 @@ class UserRequests extends React.Component {
     this.setState({request_type});
   }
 
-  chooseAWalkPlan(route_id){
+  chooseAWalkPlan(pickedRouteId, walkee_id){
     this.setState({
       showModal : true,
-      pickedRouteId : route_id
+      pickedRouteId,
+      walkee_id,
     })
   }
 
@@ -40,6 +42,7 @@ class UserRequests extends React.Component {
     this.setState({
       showModal : false,
       pickedRouteId : null,
+      walkee_id: null,
       
     })
     console.log('cancel');
@@ -58,10 +61,12 @@ class UserRequests extends React.Component {
         'Content-Type': 'application/json'
       }, 
     })
+    .then( res => res.json())
     .then( res => {
       console.log('Route status changed in DB');
-      this.props.setCurrentWalkRouteId(this.state.pickedRouteId);
-      this.props.setUserType('walker');
+      this.context.set_user_type('walker');
+      this.context.set_current_walk_paired_user_id(this.state.walkee_id);
+      this.context.set_current_walk_route_id(this.state.pickedRouteId)
       this.props.history.push('/live-walker')
     //   const routes = this.state.routes.map(route =>{
     //     if (route.id === this.state.pickedRouteId){
@@ -83,6 +88,8 @@ class UserRequests extends React.Component {
 
 
   fetchData() {
+
+
     fetch(`/api/routes/${this.context.user_id}/?request=${this.state.request_type}` ,{
       method: 'GET',
     })
@@ -126,7 +133,7 @@ class UserRequests extends React.Component {
               Create at: {route['create_at']}
             </div>
             {this.state.request_type ==='my-walk' ? 
-              <button onClick={()=>{this.chooseAWalkPlan(route.id)}}>Start this walk</button> : null
+              <button onClick={()=>{this.chooseAWalkPlan(route.id,route.walkee_id)}}>Start this walk</button> : null
             }
 
           </div>

--- a/client/components/walkee-map.jsx
+++ b/client/components/walkee-map.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import openSocket from 'socket.io-client';
+
 import MapContainer from './map-container';
+import AuthContext from '../auth-context'
 import '../css/route.css'
 
 
@@ -14,6 +16,8 @@ class WalkeeMap extends React.Component {
     
     };
   }
+
+  static contextType = AuthContext;
   componentDidMount(){
     fetch('/api/geo-locations', {
       method: 'GET',
@@ -30,12 +34,17 @@ class WalkeeMap extends React.Component {
       this.setState({ geoLocationStream }, ()=> { console.log(this.state.geoLocationStream)});
     });
 
+    
+    const socket = openSocket('http://localhost:3001');
+    // socket.id = this.context.user_id;
+    console.log('socket:', socket)
+    socket.on('new-geo-location', data => {
+      console.log("Socket Client received",data);
+      if (data.current_walk_paired_user_id === this.context.user_id ) {
+        let geoLocationStream = this.state.geoLocationStream.concat({lat: data.latitude / Math.pow(10, 7) , lng: data.longitude / Math.pow(10, 7) });
+        this.setState({ geoLocationStream }, ()=> { console.log(this.state.geoLocationStream)})
+      }
 
-    const socket = openSocket();
-    socket.on('mySQL', data => {
-      console.log("Socket Client received");
-      let geoLocationStream = this.state.geoLocationStream.concat({lat: data.latitude / Math.pow(10, 7) , lng: data.longitude / Math.pow(10, 7) });
-      this.setState({ geoLocationStream }, ()=> { console.log(this.state.geoLocationStream)})
     });
   }
 

--- a/client/components/walker-map.jsx
+++ b/client/components/walker-map.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { geolocated } from "react-geolocated";
 
 import MapContainer from './map-container'
+import AuthContext from '../auth-context'
  
 class WalkerMap extends React.Component {
 
@@ -13,18 +14,24 @@ class WalkerMap extends React.Component {
         }
     }
 
+    static contextType = AuthContext;
+
     componentDidUpdate(prevProps){
+        if (this.props.route_id > 0 && this.props.walkee_id > 0)
         if (this.props.coords) 
             if (!prevProps.coords || 
                 (this.props.coords.latitude !== prevProps.coords.latitude || this.props.coords.longitude !== prevProps.coords.longitude)){
                     const longitude = Math.floor(this.props.coords.longitude * Math.pow(10, 7));
                     const latitude = Math.floor(this.props.coords.latitude * Math.pow(10, 7));
-                    console.log(this.props.route_id)
+                    
                     const data = {
                         longitude,
                         latitude,
-                        route_id : this.props.route_id
+                        route_id : this.props.route_id,
+                        walkee_id: this.props.walkee_id,
                     };
+                    console.log("Geo locaiton post data:",data)
+
                     fetch('/api/geo-locations', {
                         method: 'POST',
                         body: JSON.stringify(data),

--- a/client/walk-context.js
+++ b/client/walk-context.js
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const walkContext = React.createContext({
-    current_walk_route_id : 0,
-    current_user_type: null
-});
-
-
-export default walkContext;

--- a/files/Queries.txt
+++ b/files/Queries.txt
@@ -2,5 +2,8 @@ DELETE FROM `geo_locations` WHERE `route_id` = 2;
 
 UPDATE `geo_locations` SET `route_id` = 5;
 
-UPDATE `routes` SET `provider_id`= 1,`status`='paired' WHERE beneficiary_id =2
+UPDATE `routes` SET `provider_id`= 1,`status`='paired' WHERE beneficiary_id = 2
+
+DELETE FROM `geo_locations` WHERE route_id != 5;
+
 

--- a/server/controllers/geo-location.js
+++ b/server/controllers/geo-location.js
@@ -21,16 +21,22 @@ exports.postGeoLocation = (req, res, next) => {
   const longitude = req.body.longitude;
   const latitude = req.body.latitude;
   const route_id = req.body.route_id;
+  const current_walk_paired_user_id = req.body.walkee_id;
   const geo_location = new GeoLocations(null, longitude, latitude, route_id, null);
+
   geo_location
   .save()
   .then((result) => {
     
+    // .to(current_walk_paired_user_id)
     console.log("new geo_location updated to mySQL: ", result);
-    io.getIO().emit('mySQL', {
+    const emitData = {
       latitude,
-      longitude
-    });
+      longitude,
+      current_walk_paired_user_id,
+    }
+    console.log("Emit data:", emitData)
+    io.getIO().emit('new-geo-location', emitData);
     res.send(result);
   })
   .catch(err => console.log("postGeoLocation controller error:" , err));

--- a/server/models/geo-location.js
+++ b/server/models/geo-location.js
@@ -22,13 +22,10 @@ module.exports = class GeoLocation {
   static deleteById(id) {}
 
   static fetchAll() {
-    return db.execute('SELECT * FROM `geo_locations` WHERE `route_id` = 2');
+    return db.execute('SELECT * FROM `geo_locations` WHERE `route_id` = 3');
   
   }
 
-  static findById(id) {
-    return db.execute('SELECT * FROM geo-locations WHERE geo_locations.id = ?', [id]);
-  }
 };
 
 // DELETE FROM `geo_locations` WHERE `route_id` = 2 

--- a/server/models/route.js
+++ b/server/models/route.js
@@ -23,7 +23,7 @@ module.exports = class Route {
   static fetchAllByRequestType(user_id, requestType) {//my-walk, walk-for-me
 
     if (requestType === 'my-walk'){
-      return db.execute(`SELECT R.id, U.username AS 'i-walk-for', status, create_at, start_at, complete_at 
+      return db.execute(`SELECT R.id, U.id AS 'walkee_id', U.username AS 'i-walk-for', status, create_at, start_at, complete_at 
       FROM routes AS R
       LEFT JOIN users AS U 
       ON beneficiary_id = U.id

--- a/server/routes/geo-location.js
+++ b/server/routes/geo-location.js
@@ -5,7 +5,6 @@ const geoLocationController = require('../controllers/geo-location');
 const router = express.Router();
 
 router.get('/geo-locations', geoLocationController.getGeoLocations);
-
 router.post('/geo-locations', geoLocationController.postGeoLocation);
 
 


### PR DESCRIPTION
https://www.meistertask.com/app/task/4LQaBCLS/walkee-able-to-see-the-walk-path

Arbitrary walkee can see arbitrary walker live walk path on map now
When geo-locations updates, current logic is able to inform another user by socket.IO. However, Socket is not sending back walkee user id, it's all the users can see that live walk path for now. This is not an expected behaviour.
move  current_walk_route_id, current_walk_paired_user_id,user_type to walk-context
merge user-context and walk-context , because build up static contextType = combinedContext has too much work : https://stackoverflow.com/questions/53988193/how-to-get-multiple-static-contexts-in-new-context-api-in-react-v16-6
Update code in walkerMap, besides geolocation data, the component will send the walkee id as well.
The walkee id is never been passed to froentend from mysql. Modify the query to include this id
Setup socket in node to only emit to walkee
In react, setup socket to only receive that data with that walkee_id
Should have use namespace or socket ID for user to user emit, but haven't found a right document for current version. will implement this later. For now, pass the paried_user_id from node to every client, then check if the local client id = emit user_id, if yes, will render the walk on map

![arbitrary walkee can see live walk now](https://user-images.githubusercontent.com/34258544/59072312-005b9b00-8877-11e9-98de-c104374193e1.gif)